### PR TITLE
Add concurrent task limit feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ Download a copy of *A Christmas Carol* by Charles Dickens:
 curl https://raw.githubusercontent.com/circlemind-ai/fast-graphrag/refs/heads/main/mock_data.txt > ./book.txt
 ```
 
+Optional: Set the limit for concurrent requests (e.g., to control the number of tasks processed simultaneously)
+```bash
+export CONCURRENT_TASK_LIMIT=8
+```
+
 Use the Python snippet below:
 
 ```python

--- a/fast_graphrag/_llm/_llm_openai.py
+++ b/fast_graphrag/_llm/_llm_openai.py
@@ -1,5 +1,5 @@
 """LLM Services module."""
-
+import os
 import asyncio
 from dataclasses import dataclass, field
 from itertools import chain
@@ -57,7 +57,7 @@ class OpenAILLMService(BaseLLMService):
             raise ValueError("Invalid client type. Must be 'openai' or 'azure'")
         logger.debug("Initialized OpenAILLMService with patched OpenAI client.")
 
-    @throttle_async_func_call(max_concurrent=1024, stagger_time=0.001, waiting_time=0.001)
+    @throttle_async_func_call(max_concurrent=int(os.getenv("CONCURRENT_TASK_LIMIT", 1024)), stagger_time=0.001, waiting_time=0.001)
     async def send_message(
         self,
         prompt: str,

--- a/fast_graphrag/_services/_information_extraction.py
+++ b/fast_graphrag/_services/_information_extraction.py
@@ -1,5 +1,4 @@
 """Entity-Relationship extraction module."""
-import os
 import asyncio
 import re
 from dataclasses import dataclass
@@ -35,14 +34,8 @@ class DefaultInformationExtractionService(BaseInformationExtractionService[TChun
         entity_types: List[str],
     ) -> List[asyncio.Future[Optional[BaseGraphStorage[TEntity, TRelation, GTId]]]]:
         """Extract both entities and relationships from the given data."""
-        concurrent_limit = os.environ.get("CONCURRENT_TASK_LIMIT")
-        semaphore = asyncio.Semaphore(int(concurrent_limit) if concurrent_limit else float('inf'))
-
-        async def limited_extract(document: Iterable[TChunk]):
-            async with semaphore:
-                return await self._extract(llm, document, prompt_kwargs, entity_types)
         return [
-            asyncio.create_task(limited_extract(document)) for document in documents
+            asyncio.create_task(self._extract(llm, document, prompt_kwargs, entity_types)) for document in documents
         ]
 
     async def extract_entities_from_query(

--- a/fast_graphrag/_services/_information_extraction.py
+++ b/fast_graphrag/_services/_information_extraction.py
@@ -1,5 +1,5 @@
 """Entity-Relationship extraction module."""
-
+import os
 import asyncio
 import re
 from dataclasses import dataclass
@@ -35,8 +35,14 @@ class DefaultInformationExtractionService(BaseInformationExtractionService[TChun
         entity_types: List[str],
     ) -> List[asyncio.Future[Optional[BaseGraphStorage[TEntity, TRelation, GTId]]]]:
         """Extract both entities and relationships from the given data."""
+        concurrent_limit = os.environ.get("CONCURRENT_TASK_LIMIT")
+        semaphore = asyncio.Semaphore(int(concurrent_limit) if concurrent_limit else float('inf'))
+
+        async def limited_extract(document: Iterable[TChunk]):
+            async with semaphore:
+                return await self._extract(llm, document, prompt_kwargs, entity_types)
         return [
-            asyncio.create_task(self._extract(llm, document, prompt_kwargs, entity_types)) for document in documents
+            asyncio.create_task(limited_extract(document)) for document in documents
         ]
 
     async def extract_entities_from_query(


### PR DESCRIPTION
Add concurrent task limit feature, allowing maximum concurrent tasks to be set via environment variable.

Since some people will use models deployed on their own infrastructure, the concurrency of these models might not be very high. Therefore, it's necessary to impose some limitations.