### PR TITLE
Fix two infinite loops

### DIFF
--- a/fast_graphrag/_storage/_vdb_hnswlib.py
+++ b/fast_graphrag/_storage/_vdb_hnswlib.py
@@ -37,7 +37,7 @@ class HNSWVectorStorage(BaseVectorStorage[GTId, GTEmbedding]):
 
     @property
     def max_size(self) -> int:
-        return self._index.get_max_elements()
+        return self._index.get_max_elements() or self.INITIAL_MAX_ELEMENT
 
     async def upsert(
         self,


### PR DESCRIPTION
In https://github.com/circlemind-ai/fast-graphrag/issues/57 I noted that sometimes the HNSW vector storage had a max size of 0, which caused an infinite loop when resizing.

I have also noticed that the throttling decorator has an implementation that can cause infinite loops when errors are thrown from the LLM code. Replacing it with `asyncio.Semaphore` avoids the issue.