### PR TITLE
Implement Gemini/Vertex AI & Voyage AI endpoints, tokenizers and rate limiting support

### DIFF
--- a/benchmarks/create_db.bat
+++ b/benchmarks/create_db.bat
@@ -1,0 +1,8 @@
+:: 2wikimultihopqa benchmark
+:: Creating databases
+python graph_benchmark.py -n 51 -c
+python graph_benchmark.py -n 101 -c
+
+:: Evaluation (create reports)
+python graph_benchmark.py -n 51 -b
+python graph_benchmark.py -n 101 -b

--- a/examples/gemini_example.py
+++ b/examples/gemini_example.py
@@ -1,0 +1,153 @@
+import os
+
+from fast_graphrag import GraphRAG, QueryParam
+import asyncio
+from fast_graphrag._utils import logger
+from fast_graphrag._llm import GeminiLLMService, GeminiEmbeddingService #, VoyageAIEmbeddingService
+
+WORKING_DIR="./book_example"
+if not os.path.exists(WORKING_DIR):
+    os.mkdir(WORKING_DIR)
+
+GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
+
+DOMAIN = "Analyze this story and identify the characters. Focus on how they interact with each other, the locations they explore, and their relationships."
+
+EXAMPLE_QUERIES = [
+    "What is the significance of Christmas Eve in A Christmas Carol?",
+    "How does the setting of Victorian London contribute to the story's themes?",
+    "Describe the chain of events that leads to Scrooge's transformation.",
+    "How does Dickens use the different spirits (Past, Present, and Future) to guide Scrooge?",
+    "Why does Dickens choose to divide the story into \"staves\" rather than chapters?"
+]
+
+# Custom entity types for story analysis
+ENTITY_TYPES = ["Character", "Animal", "Place", "Object", "Activity", "Event"]
+
+# For VoyageAI Embeddings, higher rate limits
+# from fast_graphrag._llm import VoyageAIEmbeddingService
+# VOYAGE_API_KEY = os.getenv("VOYAGE_API_KEY")
+    
+# For PDF Processing, uses langchain and PyMuPDF
+#from langchain_community.document_loaders import PyMuPDFLoader
+#async def process_pdf(file_path: str) -> str:
+#    """Process PDFs with error handling"""
+#    if not os.path.exists(file_path):
+#        raise FileNotFoundError(f"PDF file not found: {file_path}")
+#
+#    try:
+#        loader = PyMuPDFLoader(file_path)
+#        pages = ""
+#        for page in loader.lazy_load():
+#            pages += page.page_content
+#        return pages
+#            
+#    except Exception as e:
+#        raise
+
+# Text Processing Function
+async def process_text(file_path: str) -> str:
+    """Process text file with encoding handling"""
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"Text file not found: {file_path}")
+
+    try:
+        # Try UTF-8 first, fallback to other encodings
+        encodings = ['utf-8', 'ascii', 'iso-8859-1', 'cp1252']
+        text = None
+        
+        for encoding in encodings:
+            try:
+                with open(file_path, "r", encoding=encoding) as f:
+                    text = f.read()
+                break
+            except UnicodeDecodeError:
+                continue
+                
+        if text is None:
+            raise UnicodeError("Failed to decode file with any supported encoding")
+            
+        # Clean and normalize text
+        text = text.encode('ascii', 'ignore').decode('ascii')
+        return text.strip()
+            
+    except Exception as e:
+        logger.exception("An error occurred:", exc_info=True)
+        raise
+    
+async def streaming_query_loop(rag: GraphRAG):
+    """Basic query loop for repeated questions"""
+    print("\nStreaming Query Interface (type 'exit' to quit)")
+    print("="*50)
+    
+    while True:
+        try:
+            query = input("\nYou: ").strip()
+            if query.lower() == 'exit':
+                print("\nExiting chat...")
+                break
+                
+            print("Assistant: ", end='', flush=True)
+            
+            try:
+                # Higher token limits for Gemini context windows
+                response = await rag.async_query(
+                    query,
+                    params=QueryParam(with_references=False, only_context=False, entities_max_tokens=250000, relations_max_tokens=200000, chunks_max_tokens=500000)
+                )
+                print(response.response)
+            except Exception as e:
+                import traceback
+                traceback.print_exc()
+                
+        except KeyboardInterrupt:
+            print("\nInterrupted by user")
+            break
+        except Exception as e:
+            logger.exception("An error occurred:", exc_info=True)
+            continue
+        
+### fast-graphrag example for Gemini
+async def main():     
+    try:
+        grag = GraphRAG(
+            working_dir=WORKING_DIR,
+            domain=DOMAIN,
+            example_queries="\n".join(EXAMPLE_QUERIES),
+            entity_types=ENTITY_TYPES,
+            config=GraphRAG.Config(
+                # Ensure necessary APIs have been enabled in Google Cloud, namely the Generative API
+                # Supports Vertex usage via passing project_id and locatio, or using an 'Express' API key if available. More aggressive rate limiting will be required
+                # Recommendation optionis using API keys from AI Studio, enabling Billing on the studio's project for much higher rate limits (2000 RPM for 2.0 Flash as of Feb 2025)
+                llm_service = GeminiLLMService(
+                    model="gemini-2.0-flash",
+                    api_key=GEMINI_API_KEY,
+                    temperature=0.7,
+                    rate_limit_per_minute=True,
+                    rate_limit_per_second=True,
+                    max_requests_per_minute=1950,
+                    max_requests_per_second=500
+                ),
+                embedding_service=GeminiEmbeddingService(
+                    api_key=GEMINI_API_KEY,
+                    max_requests_concurrent=100,
+                ),
+                # for Voyage AI embeddings with higher rate limits than Vertex
+                #embedding_service=VoyageAIEmbeddingService(
+                #    model="voyage-3-large",
+                #    api_key=VOYAGE_API_KEY,
+                #    embedding_dim=1024,  # the output embedding dim of the chosen model
+                #),
+            ),
+        )
+
+        file = await process_text("./book.txt")
+        await grag.async_insert(file)
+            
+        await streaming_query_loop(grag)
+    except Exception as e:
+        logger.exception("An error occurred:", exc_info=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/fast_graphrag/_llm/__init__.py
+++ b/fast_graphrag/_llm/__init__.py
@@ -6,8 +6,11 @@ __all__ = [
     "format_and_send_prompt",
     "OpenAIEmbeddingService",
     "OpenAILLMService",
+    "GeminiLLMService",
+    "GeminiEmbeddingService",
 ]
 
 from ._base import BaseEmbeddingService, BaseLLMService, format_and_send_prompt
 from ._default import DefaultEmbeddingService, DefaultLLMService
 from ._llm_openai import OpenAIEmbeddingService, OpenAILLMService
+from ._llm_genai import GeminiLLMService, GeminiEmbeddingService

--- a/fast_graphrag/_llm/__init__.py
+++ b/fast_graphrag/_llm/__init__.py
@@ -8,9 +8,11 @@ __all__ = [
     "OpenAILLMService",
     "GeminiLLMService",
     "GeminiEmbeddingService",
+    "VoyageAIEmbeddingService"
 ]
 
 from ._base import BaseEmbeddingService, BaseLLMService, format_and_send_prompt
 from ._default import DefaultEmbeddingService, DefaultLLMService
 from ._llm_openai import OpenAIEmbeddingService, OpenAILLMService
 from ._llm_genai import GeminiLLMService, GeminiEmbeddingService
+from ._llm_voyage import VoyageAIEmbeddingService

--- a/fast_graphrag/_llm/_base.py
+++ b/fast_graphrag/_llm/_base.py
@@ -1,4 +1,5 @@
 """LLM Services module."""
+import os
 import re
 
 from dataclasses import dataclass, field
@@ -53,6 +54,12 @@ class BaseLLMService:
     base_url: Optional[str] = field(default=None)
     api_key: Optional[str] = field(default=None)
     llm_async_client: Any = field(init=False, default=None)
+    max_requests_concurrent: int = field(default=int(os.getenv("CONCURRENT_TASK_LIMIT", 1024)))
+    max_requests_per_minute: int = field(default=500)
+    max_requests_per_second: int = field(default=60)
+    rate_limit_concurrency: bool = field(default=True)
+    rate_limit_per_minute: bool = field(default=False)
+    rate_limit_per_second: bool = field(default=False)
 
     def count_tokens(self, text: str) -> int:
         """
@@ -103,6 +110,12 @@ class BaseEmbeddingService:
     model: Optional[str] = field(default="text-embedding-3-small")
     base_url: Optional[str] = field(default=None)
     api_key: Optional[str] = field(default=None)
+    max_requests_concurrent: int = field(default=int(os.getenv("CONCURRENT_TASK_LIMIT", 1024)))
+    max_requests_per_minute: int = field(default=500) # Tier 1 OpenAI RPM
+    max_requests_per_second: int = field(default=100)
+    rate_limit_concurrency: bool = field(default=True)
+    rate_limit_per_minute: bool = field(default=True)
+    rate_limit_per_second: bool = field(default=False)
 
     embedding_async_client: Any = field(init=False, default=None)
 
@@ -119,3 +132,10 @@ class BaseEmbeddingService:
             list[float]: The embedding vector as a list of floats.
         """
         raise NotImplementedError
+
+class NoopAsyncContextManager:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass

--- a/fast_graphrag/_llm/_llm_genai.py
+++ b/fast_graphrag/_llm/_llm_genai.py
@@ -1,0 +1,482 @@
+"""Google Genai LLM Services module for Gemini and Vertex AI endpoints.
+
+This module provides two main services:
+• GeminiLLMService - for sending messages/requests to the language model endpoint.
+• GeminiEmbeddingService - for obtaining text embeddings via the language model.
+
+Both classes support asynchronous calls, internal retry handling using tenacity,
+and rate limiting via semaphores and AsyncLimiter.
+"""
+
+import asyncio
+import os
+import numpy as np
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple, Type, cast, Literal, Callable, Awaitable
+import instructor
+from pydantic import BaseModel, ValidationError, TypeAdapter
+import requests  # used to catch requests.exceptions.ConnectionError
+from google import genai
+
+from fast_graphrag._exceptions import LLMServiceNoResponseError
+from fast_graphrag._llm._base import BaseLLMService, BaseEmbeddingService, T_model, NoopAsyncContextManager
+from fast_graphrag._models import BaseModelAlias
+from aiolimiter import AsyncLimiter
+from itertools import chain
+from fast_graphrag._utils import logger
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from google.genai import types, errors
+from vertexai.preview.tokenization import get_tokenizer_for_model
+from json_repair import repair_json
+
+SAFETY_SETTINGS = [
+    types.SafetySetting(
+        category=types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+        threshold=types.HarmBlockThreshold.BLOCK_NONE,
+    ),
+    types.SafetySetting(
+        category=types.HarmCategory.HARM_CATEGORY_HARASSMENT,
+        threshold=types.HarmBlockThreshold.BLOCK_NONE,
+    ),
+    types.SafetySetting(
+        category=types.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+        threshold=types.HarmBlockThreshold.BLOCK_NONE,
+    ),
+    types.SafetySetting(
+        category=types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+        threshold=types.HarmBlockThreshold.BLOCK_NONE,
+    ),
+    types.SafetySetting(
+        category=types.HarmCategory.HARM_CATEGORY_CIVIC_INTEGRITY,
+        threshold=types.HarmBlockThreshold.BLOCK_NONE,
+    ),
+]
+
+# Helper function to execute an asynchronous operation with inner retry logic.
+async def _execute_with_inner_retries(
+    operation: Callable[[], Awaitable[Any]],
+    validate: Callable[[Any, int, int], bool],
+    max_attempts: int = 4,
+    short_sleep: float = 0.01,
+    error_sleep: float = 0.2,
+) -> Any:
+    """
+    Executes an asynchronous operation with a specified number of inner retry attempts.
+
+    Args:
+        operation: An async callable representing the API call.
+        validate: A function that takes (result, current_attempt, total_attempts)
+                  and returns True when the result meets the criteria.
+        max_attempts: Total number of inner attempts.
+        short_sleep: Sleep interval for minor issues.
+        error_sleep: Sleep interval for connection-related issues.
+
+    Returns:
+        The valid result returned by operation.
+
+    Raises:
+        The last encountered exception if the maximum number of attempts is exceeded.
+    """
+    last_exception: Exception = Exception("Unknown error")
+    for attempt in range(max_attempts):
+        try:
+            result = await operation()
+            if validate(result, attempt, max_attempts):
+                return result
+        except (errors.ClientError, ConnectionResetError, requests.exceptions.ConnectionError) as e:
+            last_exception = e
+        except Exception as e:
+            last_exception = e
+        # Delay before next attempt; use different sleep if it was a connection error.
+        await asyncio.sleep(
+            error_sleep if isinstance(last_exception, (ConnectionResetError, requests.exceptions.ConnectionError))
+            else short_sleep
+        )
+    raise last_exception
+
+@dataclass
+class GeminiLLMService(BaseLLMService):
+    # Core fields required to interact with the LLM endpoint.
+    model: Optional[str] = field(default="gemini-2.0-flash")
+    mode: instructor.Mode = field(default=instructor.Mode.JSON)
+    client: Literal["gemini", "vertex"] = field(default="gemini")
+    api_key: Optional[str] = field(default=None)
+    temperature: float = field(default=0.7)
+    max_requests_concurrent: int = field(default=int(os.getenv("CONCURRENT_TASK_LIMIT", 1024)))
+    max_requests_per_minute: int = field(default=2000) # Gemini Flash 2.0 has a paid developer API limit of 2000 RPM
+    max_requests_per_second: int = field(default=500)
+    project_id: Optional[str] = field(default=None)
+    location: Optional[str] = field(default=None)
+    safety_settings: list[types.SafetySetting] = field(default=SAFETY_SETTINGS)
+    candidate_count: int = field(default=1)
+
+    def __post_init__(self):
+        """
+        Post-initialization:
+        • Sets up concurrency semaphores and rate limiters based on the provided configuration.
+        • Instantiates the appropriate asynchronous LLM client for either Vertex or Gemini.
+        • Initializes a local tokenizer for the Gemini model.
+        """
+        self.llm_max_requests_concurrent = (
+            asyncio.Semaphore(self.max_requests_concurrent)
+            if self.rate_limit_concurrency
+            else NoopAsyncContextManager()
+        )
+        self.llm_per_minute_limiter = (
+            AsyncLimiter(self.max_requests_per_minute, 60)
+            if self.rate_limit_per_minute
+            else NoopAsyncContextManager()
+        )
+        self.llm_per_second_limiter = (
+            AsyncLimiter(self.max_requests_per_second, 1)
+            if self.rate_limit_per_second
+            else NoopAsyncContextManager()
+        )
+
+        # Instantiate the appropriate client based on the provided "client" value.
+        if self.client == "vertex":
+            # Ensure that either project_id and location are provided or an express API key is used.
+            assert (
+                (self.project_id is not None and self.location is not None and self.api_key is None)
+                or (self.project_id is None and self.location is None and self.api_key is not None)
+            ), "Azure OpenAI requires a project id and location, or an express API key."
+            if self.api_key is not None:
+                self.llm_async_client: genai.Client = genai.Client(vertexai=True, api_key=self.api_key)
+            else:
+                self.llm_async_client = genai.Client(vertexai=True, project=self.project_id, location=self.location)
+        elif self.client == "gemini":
+            self.llm_async_client: genai.Client = genai.Client(api_key=self.api_key)
+        else:
+            raise ValueError("Invalid client type. Must be 'openai' or 'azure'")
+
+        # Initialize local tokenizer for Gemini. Update model name if needed.
+        self.tokenizer = get_tokenizer_for_model('gemini-1.5-flash-002')
+        logger.debug("Initialized GeminiLLMService.")
+
+    def count_tokens(self, text: str) -> int:
+        """
+        Count the number of tokens in the provided text utilizing the local Gemini tokenizer.
+        
+        Args:
+            text (str): The input text whose tokens are to be counted.
+            model (Optional[str]): An optional model override (not used in current implementation).
+            **kwargs: Additional keyword arguments (currently unused).
+        
+        Returns:
+            int: Total token count.
+        """
+        return self.tokenizer.count_tokens(contents=text)
+
+    @retry(
+        stop=stop_after_attempt(8),
+        wait=wait_exponential(multiplier=1, min=4, max=60),
+        retry=retry_if_exception_type((TimeoutError, Exception)),
+    )
+    async def send_message(
+        self,
+        prompt: str,
+        model: str | None = None,
+        system_prompt: str | None = None,
+        history_messages: list[dict[str, str]] | None = None,
+        response_model: Type[T_model] | None = None,
+        **kwargs: Any,
+    ) -> Tuple[T_model, list[dict[str, str]]]:
+        """
+        Sends a message to the Gemini AI language model and handles:
+          • Concurrency and rate limiting.
+          • Request retries with inner attempt loops.
+          • Response validation/parsing including JSON repair.
+        
+        Args:
+            prompt (str): The main user input.
+            model (Optional[str]): Optional override for the model name.
+            system_prompt (Optional[str]): Optional system-level instructions.
+            history_messages (Optional[list[dict[str, str]]]): Prior conversation messages.
+            response_model (Optional[Type[T_model]]): Pydantic model (or alias) dictating the response structure.
+            temperature (float): Generation temperature setting.
+            **kwargs: Additional generation parameters (unused here).
+        
+        Returns:
+            Tuple[T_model, list[dict[str, str]]]: A tuple containing the parsed response and the updated message history.
+        
+        Raises:
+            ValueError: If the model name is missing.
+            LLMServiceNoResponseError: If no valid response is obtained after all retries.
+            errors.APIError: For unrecoverable API errors.
+        """
+        # Apply the concurrency and rate limiters.
+        async with self.llm_max_requests_concurrent:
+            async with self.llm_per_minute_limiter:
+                async with self.llm_per_second_limiter:
+                    # Determine the model to use.
+                    model = model or self.model
+                    if model is None:
+                        raise ValueError("Model name must be provided.")
+
+                    # Build message history including the current user prompt.
+                    messages: List[Dict[str, str]] = []
+                    if history_messages:
+                        messages.extend(history_messages)
+                    messages.append({"role": "user", "content": prompt})
+                    combined_prompt = "\n".join(
+                        [f"{msg['role']}: {msg['content']}" for msg in messages]
+                    )
+
+                    try:
+                        def validate_generate_content(response: Any, attempt: int, max_attempts: int) -> bool:
+                            # Require that a response exists and that "text" is non-empty.
+                            if not response or not getattr(response, "text", ""):
+                                return False
+                            # If a response model is expected, then require a parsed response on nonfinal attempts.
+                            if response_model is not None and attempt != (max_attempts - 1):
+                                if not getattr(response, "parsed", ""):
+                                    return False
+                            return True
+                        
+                        # Configure generation call with safety settings, candidate count, and temperature.
+                        generate_config = (
+                            types.GenerateContentConfig(
+                                system_instruction=system_prompt,
+                                response_mime_type="application/json",
+                                response_schema=(
+                                    (response_model.Model)
+                                    if issubclass(response_model, BaseModelAlias)
+                                    else (response_model)
+                                ),
+                                candidate_count=self.candidate_count,
+                                temperature=self.temperature,
+                                safety_settings=self.safety_settings,
+                            )
+                            if response_model
+                            else types.GenerateContentConfig(
+                                system_instruction=system_prompt,
+                                candidate_count=self.candidate_count,
+                                temperature=self.temperature,
+                                safety_settings=self.safety_settings,
+                            )
+                        )
+
+                        # Use the helper to perform the inner retries.
+                        response = await _execute_with_inner_retries(
+                            operation=lambda: self.llm_async_client.aio.models.generate_content(
+                                model=model,
+                                contents=combined_prompt,
+                                config=generate_config,
+                            ),
+                            validate=validate_generate_content,
+                            max_attempts=4,
+                            short_sleep=0.01,
+                            error_sleep=0.2,
+                        )
+
+                        if not response or not getattr(response, "text", ""):
+                            raise LLMServiceNoResponseError("Failed to obtain a valid response for content.")
+
+                        # Parse and validate the response.
+                        try:
+                            if response_model:
+                                if getattr(response, "parsed"):
+                                    if issubclass(response_model, BaseModelAlias):
+                                        llm_response = TypeAdapter(response_model.Model).validate_python(getattr(response, "parsed"))
+                                    else:
+                                        llm_response = TypeAdapter(response_model).validate_python(getattr(response, "parsed"))
+                                else:
+                                    # Attempt to repair JSON if initial parsing failed.
+                                    fixed_json = repair_json(getattr(response, "text"))
+                                    if issubclass(response_model, BaseModelAlias):
+                                        llm_response = TypeAdapter(response_model.Model).validate_json(fixed_json)
+                                    else:
+                                        llm_response = TypeAdapter(response_model).validate_json(fixed_json)
+                            else:
+                                llm_response = response.text
+                        except ValidationError as e:
+                            raise LLMServiceNoResponseError(f"Invalid JSON response: {str(e)}") from e
+
+                        # Append the AI model's response to the conversation history.
+                        messages.append(
+                            {
+                                "role": "model",
+                                "content": (
+                                    llm_response.model_dump_json()
+                                    if isinstance(llm_response, BaseModel)
+                                    else str(llm_response)
+                                ),
+                            }
+                        )
+
+                        # If working with a BaseModelAlias, convert back to the dataclass.
+                        if response_model and issubclass(response_model, BaseModelAlias):
+                            llm_response = cast(
+                                T_model,
+                                cast(BaseModelAlias.Model, llm_response).to_dataclass(llm_response),
+                            )
+
+                        return llm_response, messages
+
+                    except errors.APIError as e:
+                        # Handle API error responses:
+                        # • Rate limit errors (HTTP 429): let the retry mechanism take over.
+                        # • Other client errors (HTTP 400, 403, 404): log and raise immediately.
+                        # • Server errors (HTTP 500, 503, 504): log and raise to allow retry after a delay.
+                        if e.code == 429 or (e.details and e.details.get("code") == 429):
+                            logger.warning(f"Rate limit error encountered: {e.code} - {e.message}. Attempting retry.")
+                            raise
+                        elif e.code in (400, 403, 404):
+                            logger.error(f"Client error encountered: {e.code} - {e.message}. Check your request parameters or API key.")
+                            raise
+                        elif e.code in (500, 503, 504):
+                            logger.error(f"Server error encountered: {e.code} - {e.message}. Consider retrying after a short delay.")
+                            raise
+                        else:
+                            logger.exception(f"Unexpected API error encountered: {e.code} - {e.message}")
+                            raise
+                    except Exception as e:
+                        logger.exception(f"Unexpected error: {e}")
+                        raise
+
+
+@dataclass
+class GeminiEmbeddingService(BaseEmbeddingService):
+    """Service implementation to retrieve embeddings for texts using the Gemini model."""
+    embedding_dim: int = field(default=768)
+    max_elements_per_request: int = field(default=99) # Maximum of 100 elements per batch with Gemini
+    model: Optional[str] = field(default="text-embedding-004")
+    api_version: Optional[str] = field(default=None)
+    max_requests_concurrent: int = field(default=int(os.getenv("CONCURRENT_TASK_LIMIT", 150)))
+    max_requests_per_minute: int = field(default=80) # Google cloud enforces strict limits on batch requests to Gemini embedding endpoints
+    max_requests_per_second: int = field(default=20)
+    
+    def __post_init__(self):
+        """
+        Post-initialization:
+        • Sets up concurrency semaphores and rate limiters for embedding requests.
+        • Instantiates the asynchronous client for embedding requests.
+        """
+        self.embedding_max_requests_concurrent = (
+            asyncio.Semaphore(self.max_requests_concurrent)
+            if self.rate_limit_concurrency
+            else NoopAsyncContextManager()
+        )
+        self.embedding_per_minute_limiter = (
+            AsyncLimiter(self.max_requests_per_minute, 60)
+            if self.rate_limit_per_minute
+            else NoopAsyncContextManager()
+        )
+        self.embedding_per_second_limiter = (
+            AsyncLimiter(self.max_requests_per_second, 1)
+            if self.rate_limit_per_second
+            else NoopAsyncContextManager()
+        )
+        self.embedding_async_client: genai.Client = genai.Client(api_key=self.api_key)
+        logger.debug("Initialized GeminiEmbeddingService.")
+
+    async def encode(self, texts: list[str], model: Optional[str] = None) -> np.ndarray[Any, np.dtype[np.float32]]:
+        """
+        Obtain embedding vectors for provided input texts.
+        
+        This method internally splits the texts into batches (based on max_elements_per_request)
+        and sends concurrent requests for embedding. The responses are then concatenated into a single numpy array.
+        
+        Args:
+            texts (list[str]): List of input texts to be embedded.
+            model (Optional[str]): Optional model override; defaults to the service's model if not provided.
+        
+        Returns:
+            np.ndarray: Array of embedding vectors.
+        
+        Raises:
+            Exception: Propagates any exception encountered during embedding requests.
+        """
+        try:
+            logger.debug(f"Getting embedding for texts: {texts}")
+            model = model or self.model
+            if model is None:
+                raise ValueError("Model name must be provided.")
+
+            # Batch the texts to not exceed the maximum allowed elements per request.
+            batched_texts = [
+                texts[i * self.max_elements_per_request : (i + 1) * self.max_elements_per_request]
+                for i in range((len(texts) + self.max_elements_per_request - 1) // self.max_elements_per_request)
+            ]
+            # Execute embedding requests concurrently for all batches.
+            response = await asyncio.gather(*[self._embedding_request(batch, model) for batch in batched_texts])
+
+            # Flatten the list of responses and create the embedding numpy array.
+            data = chain(*[r for r in response])
+            embeddings = np.array([dp.values for dp in data])
+            logger.debug(f"Received embedding response: {len(embeddings)} embeddings")
+
+            return embeddings
+        except Exception as e:
+            logger.exception("An error occurred during embedding encoding:", exc_info=True)
+            raise
+
+    @retry(
+        stop=stop_after_attempt(8),
+        wait=wait_exponential(multiplier=1, min=5, max=60),
+        retry=retry_if_exception_type((TimeoutError, Exception)),
+    )
+    async def _embedding_request(self, input: list[Any], model: str) -> list[types.ContentEmbedding]:
+        """
+        Makes an embedding request for a batch of input texts.
+
+        Applies internal retry logic and rate limiting to ensure a valid response is obtained.
+        
+        Args:
+            input (list[Any]): A batch of texts to be embedded.
+            model (str): The model name to be used for generating embeddings.
+        
+        Returns:
+            list[types.ContentEmbedding]: A list of embedding objects.
+        
+        Raises:
+            LLMServiceNoResponseError: If a valid response is not obtained after retries.
+            errors.APIError: For unrecoverable API errors.
+        """
+        async with self.embedding_max_requests_concurrent:
+            async with self.embedding_per_minute_limiter:
+                async with self.embedding_per_second_limiter:
+                    try:
+                        def validate_embedding_response(response: Any, attempt: int, max_attempts: int) -> bool:
+                            if not response or not getattr(response, "embeddings", None) or getattr(response, "embeddings") == []:
+                                return False
+                            return True
+
+                        response = await _execute_with_inner_retries(
+                            operation=lambda: self.embedding_async_client.aio.models.embed_content(
+                                model=model, contents=input
+                            ),
+                            validate=validate_embedding_response,
+                            max_attempts=4,
+                            short_sleep=0.01,
+                            error_sleep=0.2,
+                        )
+
+                        if not response or not getattr(response, "embeddings", None) or getattr(response, "embeddings") == []:
+                            raise LLMServiceNoResponseError("Failed to obtain a valid response for embeddings.")
+
+                        return getattr(response, "embeddings")
+
+                    except errors.APIError as e:
+                        # Handle various API error scenarios.
+                        if e.code == 429 or (e.details and e.details.get("code") == 429):
+                            logger.warning(f"Rate limit error encountered: {e.code} - {e.message}. Delegating to outer retry.")
+                            raise
+                        elif e.code in (400, 403, 404):
+                            logger.error(f"Client error encountered: {e.code} - {e.message}. Check your request parameters or API key.")
+                            raise
+                        elif e.code in (500, 503, 504):
+                            logger.error(f"Server error encountered: {e.code} - {e.message}. Consider retrying after a short delay.")
+                            raise
+                        else:
+                            logger.exception(f"Unexpected API error encountered: {e.code} - {e.message}")
+                            raise
+                    except Exception as e:
+                        logger.exception(f"Unexpected error during embedding request: {e}")
+                        raise

--- a/fast_graphrag/_llm/_llm_genai.py
+++ b/fast_graphrag/_llm/_llm_genai.py
@@ -35,29 +35,31 @@ from google.genai import types, errors
 from vertexai.preview.tokenization import get_tokenizer_for_model
 from json_repair import repair_json
 
-SAFETY_SETTINGS = [
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_HARASSMENT,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-    types.SafetySetting(
-        category=types.HarmCategory.HARM_CATEGORY_CIVIC_INTEGRITY,
-        threshold=types.HarmBlockThreshold.BLOCK_NONE,
-    ),
-]
 
+def default_safety_settings() -> List[types.SafetySetting]:
+    return [
+        types.SafetySetting(
+            category=types.HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT,
+            threshold=types.HarmBlockThreshold.BLOCK_NONE,
+        ),
+        types.SafetySetting(
+            category=types.HarmCategory.HARM_CATEGORY_HARASSMENT,
+            threshold=types.HarmBlockThreshold.BLOCK_NONE,
+        ),
+        types.SafetySetting(
+            category=types.HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+            threshold=types.HarmBlockThreshold.BLOCK_NONE,
+        ),
+        types.SafetySetting(
+            category=types.HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT,
+            threshold=types.HarmBlockThreshold.BLOCK_NONE,
+        ),
+        types.SafetySetting(
+            category=types.HarmCategory.HARM_CATEGORY_CIVIC_INTEGRITY,
+            threshold=types.HarmBlockThreshold.BLOCK_NONE,
+        ),
+    ]
+    
 # Helper function to execute an asynchronous operation with inner retry logic.
 async def _execute_with_inner_retries(
     operation: Callable[[], Awaitable[Any]],
@@ -108,13 +110,13 @@ class GeminiLLMService(BaseLLMService):
     client: Literal["gemini", "vertex"] = field(default="gemini")
     api_key: Optional[str] = field(default=None)
     temperature: float = field(default=0.7)
+    candidate_count: int = field(default=1)
     max_requests_concurrent: int = field(default=int(os.getenv("CONCURRENT_TASK_LIMIT", 1024)))
     max_requests_per_minute: int = field(default=2000) # Gemini Flash 2.0 has a paid developer API limit of 2000 RPM
     max_requests_per_second: int = field(default=500)
     project_id: Optional[str] = field(default=None)
     location: Optional[str] = field(default=None)
-    safety_settings: list[types.SafetySetting] = field(default=SAFETY_SETTINGS)
-    candidate_count: int = field(default=1)
+    safety_settings: list[types.SafetySetting] = field(default_factory=default_safety_settings)
 
     def __post_init__(self):
         """

--- a/fast_graphrag/_llm/_llm_openai.py
+++ b/fast_graphrag/_llm/_llm_openai.py
@@ -243,4 +243,4 @@ class OpenAIEmbeddingService(BaseEmbeddingService):
         async with self.embedding_max_requests_concurrent:
             async with self.embedding_per_minute_limiter:
                 async with self.embedding_per_second_limiter:
-                        return await self.embedding_async_client.embeddings.create(model=model, input=input, encoding_format="float")
+                        return await self.embedding_async_client.embeddings.create(model=model, input=input, dimensions=self.embedding_dim, encoding_format="float")

--- a/fast_graphrag/_llm/_llm_voyage.py
+++ b/fast_graphrag/_llm/_llm_voyage.py
@@ -1,0 +1,84 @@
+"""LLM Services module."""
+import asyncio
+from dataclasses import dataclass, field
+from itertools import chain
+from typing import Any, List, Optional
+import os
+
+import numpy as np
+from voyageai import client_async
+from voyageai.object.embeddings import EmbeddingsObject
+
+from fast_graphrag._utils import logger
+
+from ._base import BaseEmbeddingService, NoopAsyncContextManager
+from aiolimiter import AsyncLimiter
+
+@dataclass
+class VoyageAIEmbeddingService(BaseEmbeddingService):
+    """Base class for VoyageAI embeddings implementations."""
+
+    embedding_dim: int = field(default=1024)
+    max_elements_per_request: int = field(default=128) # Max 128 elements per batch for Voyage API
+    model: Optional[str] = field(default="voyage-3")
+    api_version: Optional[str] = field(default=None)
+    max_requests_concurrent: int = field(default=int(os.getenv("CONCURRENT_TASK_LIMIT", 1024)))
+    max_requests_per_minute: int = field(default=1800)
+    max_requests_per_second: int = field(default=100)
+    rate_limit_per_second: bool = field(default=False)
+
+    def __post_init__(self):
+        self.embedding_max_requests_concurrent = (
+            asyncio.Semaphore(self.max_requests_concurrent)
+            if self.rate_limit_concurrency
+            else NoopAsyncContextManager()
+        )
+        self.embedding_per_minute_limiter = (
+            AsyncLimiter(self.max_requests_per_minute, 60)
+            if self.rate_limit_per_minute
+            else NoopAsyncContextManager()
+        )
+        self.embedding_per_second_limiter = (
+            AsyncLimiter(self.max_requests_per_second, 1)
+            if self.rate_limit_per_second
+            else NoopAsyncContextManager()
+        )
+        self.embedding_async_client: client_async.AsyncClient = client_async.AsyncClient(api_key=self.api_key, max_retries=4)
+        logger.debug("Initialized VoyageAIEmbeddingService.")
+
+    async def encode(self, texts: list[str], model: Optional[str] = None) -> np.ndarray[Any, np.dtype[np.float32]]:
+        try:
+            """Get the embedding representation of the input text.
+
+            Args:
+                texts (str): The input text to embed.
+                model (str, optional): The name of the model to use. Defaults to the model provided in the config.
+
+            Returns:
+                list[float]: The embedding vector as a list of floats.
+            """
+            logger.debug(f"Getting embedding for texts: {texts}")
+            model = model or self.model
+            if model is None:
+                raise ValueError("Model name must be provided.")
+
+            batched_texts = [
+                texts[i * self.max_elements_per_request : (i + 1) * self.max_elements_per_request]
+                for i in range((len(texts) + self.max_elements_per_request - 1) // self.max_elements_per_request)
+            ]
+            response = await asyncio.gather(*[self._embedding_request(b, model) for b in batched_texts])
+
+            data = chain(*[r.embeddings for r in response])
+            embeddings = np.array([dp for dp in data])
+            logger.debug(f"Received embedding response: {len(embeddings)} embeddings")
+
+            return embeddings
+        except Exception as e:
+            logger.exception("An error occurred:", exc_info=True)
+            raise
+
+    async def _embedding_request(self, input: List[str], model: str) -> EmbeddingsObject:
+        async with self.embedding_max_requests_concurrent:
+            async with self.embedding_per_minute_limiter:
+                async with self.embedding_per_second_limiter:
+                        return await self.embedding_async_client.embed(model=model, texts=input, output_dimension=self.embedding_dim)

--- a/fast_graphrag/_prompt.py
+++ b/fast_graphrag/_prompt.py
@@ -5,66 +5,84 @@ from typing import Any, Dict
 PROMPTS: Dict[str, Any] = {}
 
 ## NEW
-PROMPTS["entity_relationship_extraction"] = """# DOMAIN PROMPT
+
+entity_relationship_extraction_text = """# DOMAIN
 {domain}
 
 # GOAL
-Your goal is to highlight information that is relevant to the domain and the questions that may be asked on it.
-Given an input document, identify all relevant entities and all relationships among them.
+Your goal is to highlight information that is relevant to the domain and the queries that may be asked on it. Given an input document, identify all relevant entities and all relationships among them.
 
-Examples of possible questions:
+Examples of possible queries:
 {example_queries}
 
-# STEPS
-1. Identify all entities of the given types. Make sure to extract all and only the entities that are of one of the given types. Use singular names and split compound concepts when necessary (for example, from the sentence "they are movie and theater directors", you should extract the entities "movie director" and "theater director").
-2. Identify all relationships between the entities found in step 1. Clearly resolve pronouns to their specific names to maintain clarity.
-3. Double check that each entity identified in step 1 appears in at least one relationship. If not, add the missing relationships.
+# INSTRUCTIONS
+1. **ENTITY IDENTIFICATION**: Identify and meticulously extract all entities mentioned in the document that belong to the provided ENTITY TYPES. For each entity, provide a concise description capturing its key features within the document's context. Use singular entity names and split compound concepts when necessary for clarity.
+2. **RELATIONSHIP DISCOVERY**: Identify and describe ALL relationships between the extracted entities. Resolve pronouns to entity names for clarity. Ensure relationship descriptions clearly explain the connection between entities.
+3. **ENTITY COVERAGE CHECK**: Verify that every identified entity is part of at least one relationship. If any entity is isolated, infer and add a relationship to connect it to the graph, even if the relationship is implicit.
+4. **OUTPUT FORMAT: STRICTLY VALID JSON**: Output MUST be in strictly valid JSON format.  Adhere to ALL standard JSON rules. The JSON MUST contain three top-level lists: "entities", "relationships", and "other_relationships". Each list item must be a JSON object with the REQUIRED fields ("name", "type", "desc" for entities; "source", "target", "desc" for relationships), all as JSON strings enclosed in DOUBLE QUOTES ONLY.  **ABSOLUTELY NO SINGLE QUOTES, BRACKETS FOR STRINGS, TRAILING COMMAS, OR MARKDOWN FORMATTING (like triple backticks) ARE PERMITTED.**  Invalid JSON output is unacceptable.
 
-# EXAMPLE DATA
-Example types: [location, organization, person, communication]
-Example document: Radio City: Radio City is India's first private FM radio station and was started on 3 July 2001. It plays Hindi, English and regional songs. Radio City recently forayed into new media in May 2008 with the launch of a music portal - PlanetRadiocity.com that offers music related news, videos, songs, and other music-related features."
+# EXAMPLE INPUT DATA
+Allowed Entity Types: [location, organization, person, communication]
+Document: "Radio City: Radio City is India's first private FM radio station and was started on 3 July 2001. It plays Hindi, English and regional songs. Radio City recently forayed into new media in May 2008 with the launch of a music portal - PlanetRadiocity.com that offers music related news, videos, songs, and other music-related features."
 
-Output:
+# EXAMPLE OUTPUT DATA (VALID JSON - DO NOT DEVIATE)
 {{
-"entities": [
-	{{"name": "RADIO CITY", "type": "organization", "desc": "Radio City is India's first private FM radio station"}},
-	{{"name": "INDIA", "type": "location", "desc": "A country"}},
-	{{"name": "FM RADIO STATION", "type": "communication", "desc": "A radio station that broadcasts using frequency modulation"}},
-	{{"name": "ENGLISH", "type": "communication", "desc": "A language"}},
-	{{"name": "HINDI", "type": "communication", "desc": "A language"}},
-	{{"name": "NEW MEDIA", "type": "communication", "desc": "New media"}},
-	{{"name": "PLANETRADIOCITY", "type": "organization", "desc": "PlanetRadiocity.com is an online music portal"}},
-	{{"name": "MUSIC PORTAL", "type": "communication", "desc": "A website that offers music related information"}},
-	{{"name": "NEWS", "type": "communication", "desc": "News"}},
-	{{"name": "VIDEO", "type": "communication", "desc": "Video"}},
-	{{"name": "SONG", "type": "communication", "desc": "Song"}}
-],
-"relationships": [
-	{{"source": "RADIO CITY", "target": "INDIA", "desc": "Radio City is located in India"}},
-	{{"source": "RADIO CITY", "target": "FM RADIO STATION", "desc": "Radio City is a private FM radio station started on 3 July 2001"}},
-	{{"source": "RADIO CITY", "target": "ENGLISH", "desc": "Radio City broadcasts English songs"}},
-	{{"source": "RADIO CITY", "target": "HINDI", "desc": "Radio City broadcasts songs in the Hindi language"}},
-	{{"source": "RADIO CITY", "target": "PLANETRADIOCITY", "desc": "Radio City launched PlanetRadiocity.com in May 2008"}},
-	{{"source": "PLANETRADIOCITY", "target": "MUSIC PORTAL", "desc": "PlanetRadiocity.com is a music portal"}},
-	{{"source": "PLANETRADIOCITY", "target": "NEWS", "desc": "PlanetRadiocity.com offers music related news"}},
-	{{"source": "PLANETRADIOCITY", "target": "SONG", "desc": "PlanetRadiocity.com offers songs"}}
-],
-"other_relationships": [
-	{{"source": "RADIO CITY", "target": "NEW MEDIA", "desc": "Radio City forayed into new media in May 2008."}},
-	{{"source": "PLANETRADIOCITY", "target": "VIDEO", "desc": "PlanetRadiocity.com offers music related videos"}}
-]
+  "entities": [
+    {{"name": "RADIO CITY", "type": "organization", "desc": "India's first private FM radio station"}},
+    {{"name": "INDIA", "type": "location", "desc": "A country in South Asia"}},
+    {{"name": "FM RADIO STATION", "type": "communication", "desc": "A radio broadcasting service using frequency modulation"}},
+    {{"name": "ENGLISH", "type": "communication", "desc": "A language of global communication"}},
+    {{"name": "HINDI", "type": "communication", "desc": "An Indo-Aryan language of India"}},
+    {{"name": "NEW MEDIA", "type": "communication", "desc": "Digital forms of media content"}},
+    {{"name": "PLANETRADIOCITY", "type": "organization", "desc": "An online platform for music and entertainment"}},
+    {{"name": "MUSIC PORTAL", "type": "communication", "desc": "A website dedicated to music-related content"}},
+    {{"name": "NEWS", "type": "communication", "desc": "Reports on current events, especially in music"}},
+    {{"name": "VIDEO", "type": "communication", "desc": "Moving visual content, often music-related"}},
+    {{"name": "SONG", "type": "communication", "desc": "A musical composition with lyrics"}}
+  ],
+  "relationships": [
+    {{"source": "RADIO CITY", "target": "INDIA", "desc": "Radio City is geographically situated in India"}},
+    {{"source": "RADIO CITY", "target": "FM RADIO STATION", "desc": "Radio City operates as a private FM radio station, launched on July 3, 2001"}},
+    {{"source": "RADIO CITY", "target": "ENGLISH", "desc": "Radio City's broadcasts include songs in the English language"}},
+    {{"source": "RADIO CITY", "target": "HINDI", "desc": "Radio City's broadcasts also feature songs in the Hindi language"}},
+    {{"source": "RADIO CITY", "target": "PLANETRADIOCITY", "desc": "Radio City expanded into new media with PlanetRadiocity.com in May 2008"}},
+    {{"source": "PLANETRADIOCITY", "target": "MUSIC PORTAL", "desc": "PlanetRadiocity.com functions as a music portal"}},
+    {{"source": "PLANETRADIOCITY", "target": "NEWS", "desc": "PlanetRadiocity.com provides music-related news content"}},
+    {{"source": "PLANETRADIOCITY", "target": "SONG", "desc": "PlanetRadiocity.com makes songs available to users"}}
+  ],
+  "other_relationships": [
+    {{"source": "RADIO CITY", "target": "NEW MEDIA", "desc": "Radio City's foray into new media occurred in May 2008"}},
+    {{"source": "PLANETRADIOCITY", "target": "VIDEO", "desc": "PlanetRadiocity.com includes music-related video content"}}
+  ]
 }}
-
-# INPUT DATA
-Types: {entity_types}
-Document: {input_text}
-
-Output:
 """
 
-PROMPTS["entity_relationship_continue_extraction"] = "MANY entities were missed in the last extraction.  Add them below using the same format:"
+PROMPTS["entity_relationship_extraction_system"] = entity_relationship_extraction_text
+PROMPTS["entity_relationship_extraction_prompt"] = """**IMPORTANT JSON FORMATTING RULES:**
+- **Output strictly valid JSON with all identified entities and relationships as per the example.**
+- Do NOT use brackets or single quotes `(}},],')` to enclose strings within JSON.
+- Ensure there are NO trailing commas in lists or objects.
+- Output MUST be a single, valid JSON object. Do NOT wrap the JSON output in triple backticks or any other markdown formatting.
 
-PROMPTS["entity_relationship_gleaning_done_extraction"] = "Retrospectively check if all entities have been correctly identified: answer done if so, or continue if there are still entities that need to be added."
+# INPUT DATA
+<<ENTITY_TYPES_START>>
+**Entity Types**: 
+{entity_types}
+<<ENTITY_TYPES_END>>
+
+<<DOCUMENT_START>>
+**Document**: 
+{input_text}
+<<DOCUMENT_END>>
+
+OUTPUT:
+"""
+
+PROMPTS["entity_relationship_continue_extraction_system"] = entity_relationship_extraction_text
+PROMPTS["entity_relationship_continue_extraction_prompt"] = "MANY entities were missed in the last extraction.  Add them below using the same format:"
+
+PROMPTS["entity_relationship_gleaning_done_extraction_system"] = entity_relationship_extraction_text
+PROMPTS["entity_relationship_gleaning_done_extraction_prompt"] = "Retrospectively check if all entities have been correctly identified: answer done if so, or continue if there are still entities that need to be added."
 
 PROMPTS["entity_extraction_query"] = """Given the query below, your task is to extract all entities relevant to perform information retrieval to produce an answer.
 

--- a/fast_graphrag/_types.py
+++ b/fast_graphrag/_types.py
@@ -130,9 +130,9 @@ class TEntity(BaseModelAlias, BTNode):
         return s
 
     class Model(BaseModelAlias.Model, alias="Entity"):
-        name: str = Field(..., description="Name of the entity")
-        type: str = Field(..., description="Type of the entity")
-        desc: str = Field(..., description="Description of the entity")
+        name: str = Field(..., description="Name of the entity",json_schema_extra={"example": ""})
+        type: str = Field(..., description="Type of the entity",json_schema_extra={"example": ""})
+        desc: str = Field(..., description="Description of the entity",json_schema_extra={"example": ""})
 
         @staticmethod
         def to_dataclass(pydantic: "TEntity.Model") -> "TEntity":
@@ -196,10 +196,10 @@ class TRelation(BaseModelAlias, BTEdge):
             return {}
 
     class Model(BaseModelAlias.Model, alias="Relationship"):
-        source: str = Field(..., description="Name of the source entity")
-        target: str = Field(..., description="Name of the target entity")
+        source: str = Field(..., description="Name of the source entity",json_schema_extra={"example": ""})
+        target: str = Field(..., description="Name of the target entity",json_schema_extra={"example": ""})
         # alternative description "Explanation of why the source entity and the target entity are related to each other"
-        desc: str = Field(..., description="Description of the relationship between the source and target entity")
+        desc: str = Field(..., description="Description of the relationship between the source and target entity",json_schema_extra={"example": ""})
 
         @staticmethod
         def to_dataclass(pydantic: "TRelation.Model") -> "TRelation":
@@ -222,13 +222,13 @@ class TGraph(BaseModelAlias):
     relationships: List[TRelation] = field()
 
     class Model(BaseModelAlias.Model, alias="Graph"):
-        entities: List[TEntity.Model] = Field(description="List of extracted entities")
-        relationships: List[TRelation.Model] = Field(description="Relationships between the entities")
+        entities: List[TEntity.Model] = Field(description="List of extracted entities",json_schema_extra={"example": []})
+        relationships: List[TRelation.Model] = Field(description="Relationships between the entities",json_schema_extra={"example": []})
         other_relationships: List[TRelation.Model] = Field(
             description=(
                 "Other relationships between the extracted entities previously missed"
                 "(likely involving minor/generic entities)"
-            )
+            ),json_schema_extra={"example": []}
         )
 
         @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ hnswlib = "^0.8.0"
 instructor = "^1.6.3"
 requests = "^2.32.3"
 python-dotenv = "^1.0.1"
+tiktoken = "^0.8.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ instructor = "^1.6.3"
 requests = "^2.32.3"
 python-dotenv = "^1.0.1"
 tiktoken = "^0.8.0"
+aiolimiter = "^1.1.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Provides a complete, native endpoint for both Google Gemini and Vertex AI using the new python-genai SDK for Flash 2.0, supporting both LLM calls and embeddings. 

To allow this to function with many of the aggressive rate limits for Vertex AI and some embeddings endpoints, all LLM classes now use the aiolimiter library to support both rate limiting per second and per minute, with an asyncio Sempahore used to handle a concurrent requests limit similar to the prior throttle_async functions.

Further supports Voyage AI embeddings to allow use of voyage-3 models, tuned for tier 1 rate limits and set to a reasonable 1024 embeddings dimension by default. 

Additional improvements include tokenizers for both the base LLM class (using a naive implementation) and for both OpenAI (using tiktoken with naive fallback) and Gemini (using Flash 1.5 as the base tokenizer), support for custom embedding dimensions for the OpenAI embeddings endpoint and improved exception handling.

### Reasoning
Considering the cost of Gemini Flash 2.0 vs other models, and the quality + context window capabilities of Flash 2.0 vs 4o-mini, supporting Gemini allows GraphRAG to be more cost-effective for larger datasets without causing significant issues with latency or quality. VoyageAI also allows using some of the highest quality embedding models currently available.

Moving to time-based rate limits also supports the reality of most API's today, with concurrent calls taking second priority to tier-limits. This is especially true for some providers such as Openrouter (with per-second limits) and Google/Vertex AI (which enforces 150 requests per minute for batched embeddings).