### PR TITLE
fix: multiply the embedding list by their dimension to get the real size

### DIFF
--- a/fast_graphrag/_storage/_vdb_hnswlib.py
+++ b/fast_graphrag/_storage/_vdb_hnswlib.py
@@ -53,7 +53,7 @@ class HNSWVectorStorage(BaseVectorStorage[GTId, GTEmbedding]):
             metadata is None or (len(metadata) == len(ids))
         ), "ids, embeddings, and metadata (if provided) must have the same length"
 
-        if self.size + len(embeddings) >= self.max_size:
+        if self.size + len(embeddings)*self.embedding_dim >= self.max_size:
             new_size = self.max_size * 2
             while self.size + len(embeddings) >= new_size:
                 new_size *= 2


### PR DESCRIPTION
The current is not working, I got the error:
self._index.add_items(data=embeddings, ids=ids, num_threads=self.config.num_threads)
RuntimeError: The number of elements exceeds the specified limit
We need to multiply each element of the embedding list by their side (which is constant: self.embedding_dim) in the line 56 :
if self.size + len(embeddings)*self.embedding_dim >= self.max_size: