### PR TITLE
FEAT: use pydantic response model for structured output

### DIFF
--- a/fast_graphrag/_graphrag.py
+++ b/fast_graphrag/_graphrag.py
@@ -14,6 +14,7 @@ from fast_graphrag._services._state_manager import BaseStateManagerService
 from fast_graphrag._storage._base import BaseGraphStorage, BaseIndexedKeyValueStorage, BaseVectorStorage
 from fast_graphrag._types import GTChunk, GTEdge, GTEmbedding, GTHash, GTId, GTNode, TContext, TDocument, TQueryResponse
 from fast_graphrag._utils import TOKEN_TO_CHAR_RATIO, get_event_loop, logger
+from pydantic import BaseModel
 
 
 @dataclass
@@ -142,11 +143,11 @@ class BaseGraphRAG(Generic[GTEmbedding, GTHash, GTChunk, GTNode, GTEdge, GTId]):
             logger.error(f"Error during insertion: {e}")
             raise e
 
-    def query(self, query: str, params: Optional[QueryParam] = None) -> TQueryResponse[GTNode, GTEdge, GTHash, GTChunk]:
+    def query(self, query: str, params: Optional[QueryParam] = None, response_model = None) -> TQueryResponse[GTNode, GTEdge, GTHash, GTChunk]:
         async def _query() -> TQueryResponse[GTNode, GTEdge, GTHash, GTChunk]:
             await self.state_manager.query_start()
             try:
-                answer = await self.async_query(query, params)
+                answer = await self.async_query(query, params, response_model)
                 return answer
             except Exception as e:
                 logger.error(f"Error during query: {e}")
@@ -157,7 +158,7 @@ class BaseGraphRAG(Generic[GTEmbedding, GTHash, GTChunk, GTNode, GTEdge, GTId]):
         return get_event_loop().run_until_complete(_query())
 
     async def async_query(
-        self, query: Optional[str], params: Optional[QueryParam] = None
+        self, query: Optional[str], params: Optional[QueryParam] = None, response_model = None
     ) -> TQueryResponse[GTNode, GTEdge, GTHash, GTChunk]:
         """Query the graph with a given input.
 
@@ -199,6 +200,7 @@ class BaseGraphRAG(Generic[GTEmbedding, GTHash, GTChunk, GTNode, GTEdge, GTId]):
         if params.only_context:
             answer = ""
         else:
+            response_model = TAnswer if response_model is None else response_model
             llm_response, _ = await format_and_send_prompt(
                 prompt_key="generate_response_query_with_references"
                 if params.with_references
@@ -208,9 +210,12 @@ class BaseGraphRAG(Generic[GTEmbedding, GTHash, GTChunk, GTNode, GTEdge, GTId]):
                     "query": query,
                     "context": context_str
                 },
-                response_model=TAnswer,
+                response_model=response_model,
             )
-            answer = llm_response.answer
+            if response_model is None:
+                answer = llm_response.answer
+            else:
+                answer = llm_response
 
         return TQueryResponse[GTNode, GTEdge, GTHash, GTChunk](response=answer, context=context)
 


### PR DESCRIPTION
# Directly Query for Pydantic Objects with GraphRAG
This PR introduces a powerful new feature that allows you to directly receive a Pydantic object as the result of a GraphRAG query. This significantly streamlines data handling and validation, enabling you to work with structured, type-hinted outputs immediately.

## How to Use
By simply passing a Pydantic BaseModel as the response_model argument to the grag.query() method, GraphRAG will automatically parse and validate the query's output into an instance of your specified model.

## Here's an example:

```python 
from typing import Annotated, List, Optional
from pydantic import BaseModel, Field
from fast_graphrag import GraphRAG

class GraphRAGTheme(BaseModel):
    """A single theme generated by GraphRAG."""
    theme_name: str = Field(description="Name of the theme")
    keywords: List[str] = Field(description="Keywords associated with the theme")

class GraphRAGThemeList(BaseModel):
    """List of themes generated by GraphRAG."""
    themes: List[GraphRAGTheme] = Field(description="List of generated themes")
    city_name: str = Field(description="Name of the city")
    total_themes: int = Field(description="Total number of themes generated")

query = 'your query....'
grag = GraphRAG(....)

# Directly get a Pydantic object from the query result
result: GraphRAGThemeList = grag.query(query, response_model=GraphRAGThemeList)

# You can now access your data with full type hinting and validation
print(result.city_name)
for theme in result.themes:
    print(theme.theme_name)

```